### PR TITLE
Update lib.mjs - Promises handler

### DIFF
--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -8,34 +8,32 @@ export function Limiter(n, { limit = 10, timeout = null, threshold = 3 / 4 } = {
 
   return {
     flush() {
-      return Promise.all(ring);
+      return Promise.allSettled(ring);
     },
 
     add($fn) {
       const offset = o = ++o % ring.length;
-
       ring[offset] = ring[offset].then(
         tasks < unchecked
-          ? () => (tasks += 1, $fn().then(() => Atomics.notify(i32, 0, limit - --tasks)))
-
+          ? () => (++tasks, $fn().then(() => Atomics.notify(i32, 0, limit - --tasks)))
           : async () => {
             if (limit === tasks) await Atomics.waitAsync(i32, 0, 0).value;
 
-            tasks += 1;
+            ++tasks;
             const $task = $fn();
 
             if (!timeout) {
               await $task;
               Atomics.notify(i32, 0, limit - --tasks);
-            }
-
-            else {
+            } else {
               let esc;
-              const $escape = new Promise(r => esc = r);
+              const $escape = new Promise(r => (esc = r));
               const $timeout = setTimeout(esc, timeout, token);
-              if (token === await Promise.race([$task, $escape]))
-                $task.then(() => Atomics.notify(i32, 0, limit - --tasks));
-                else (clearTimeout($timeout), Atomics.notify(i32, 0, limit - --tasks));
+              if (token === await Promise.race([$task, $escape])) $task.then(() => (Atomics.notify(i32, 0, limit - --tasks)));
+              else (
+                clearTimeout($timeout), 
+                Atomics.notify(i32, 0, limit - --tasks)
+              );
             }
           }
       );


### PR DESCRIPTION
Simple modification of the “flush” function: use Promise.allSettled to manage all promises in the list, including those that are rejected, unlike Promise.all.